### PR TITLE
Changed visualization of lacking portforward: fixes #19

### DIFF
--- a/src/common/docker/dockerode.ts
+++ b/src/common/docker/dockerode.ts
@@ -194,7 +194,11 @@ export class Dockerode {
             let mode = container.HostConfig.NetworkMode;
             row.push(container.NetworkSettings.Networks[mode == 'default' ? 'bridge' : mode].IPAddress);
             if (container.Ports.length > 0) {
-                const ports = container.Ports.map(port => port.PrivatePort + ':' + port.PublicPort).join(' ');
+                const ports = container.Ports.map(port => (
+                    port.PrivatePort + (
+                        port.PublicPort !== undefined ? (":" + port.PublicPort) : ""
+                    )
+                )).join(' ');
                 row.push(ports.toString());
             } else {
                 row.push('-');


### PR DESCRIPTION
This changes the format from un-forwarded ports be shown as `80` rather than  `80:undefined` - I considered multiple variants. Also `80:`, `80:NA`, but i think simply listing the port is the prettiest, however am open for suggestions.

Please, if you can, also add the `hacktoberfest-accepted` label to this PR so i can get some sweet hacktoberfest swag. Otherwise i won't get any credit. Alternatively you can also add the `hacktoberfest` label to your repo if you want contributions. 